### PR TITLE
Fix exports when isolatedModules is true

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,5 +4,5 @@ export { NotifierComponents };
 export { Notifier, NotifierRoot } from './Notifier';
 export { Easing } from 'react-native';
 export * from './NotifierWrapper';
-export { NotifierInterface, QueueMode } from './types';
-export { AlertComponentProps } from './components/Alert';
+export type { NotifierInterface, QueueMode } from './types';
+export type { AlertComponentProps } from './components/Alert';


### PR DESCRIPTION
In the web environment there is a compilation error:

`Cannot re-export a type when the '--isolatedModules' flag is provided.`

According the following links an interface must be exported as type using `export type` syntax:
https://github.com/microsoft/TypeScript/issues/28481
https://github.com/microsoft/TypeScript/issues/32662